### PR TITLE
docs: feedback

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -121,6 +121,8 @@ export const converter = (
 ): typeof nRFAssetTrackerReported => {
 	const result = {} as typeof nRFAssetTrackerReported
 	const device = input[Device_3_urn]
+	// There is short cut for this using destructuring object
+	// const { [Device_3_urn]: device, [Temperature_3303_urn]: temperature } = input
 	const temperature = input[Temperature_3303_urn]
 	const humidity = input[Humidity_3304_urn]
 	const pressure = input[Pressure_3323_urn]

--- a/src/utils/getBat.ts
+++ b/src/utils/getBat.ts
@@ -26,7 +26,11 @@ export const getBat = (
 		}
 
 	const value = device['7'] != null ? device['7'][0] : undefined
+	// You can make short cut there
+	// const value = device['7']?.[0]
 	const time = device['13'] != null ? device['13'] * 1000 : undefined
+	// I would make it clear by using
+	// device['13'] !== null && device['13'] !== undefined
 
 	const object = {
 		v: value,

--- a/src/utils/getGnss.ts
+++ b/src/utils/getGnss.ts
@@ -31,6 +31,9 @@ export const getGnss = (
 	const lng = location['1']
 	const acc = location['3']
 	const time = location['5'] != null ? location['5'] * 1000 : undefined
+	// Alternative way
+	// const { 0: lat, 2: alt, 6: spd, 1: lng, 3: acc, 5: maybeTime } = location
+	// const time = (maybeTime !== null && maybeTime !== undefined) ? maybeTime * 1000 : undefined
 
 	/**
 	 * hdg from GNSS object is not provided.


### PR DESCRIPTION
# docs: link ADR 008 with a test

I am not sure whether we can detect the version from the somewhere. If so, I think the library should detect that and throw error / warning to user that we don't support.

# docs: link documentation with JSDocs

I prefer `@see https://github.com/MLopezJ/asset-tracker-cloud-coiote-azure-converter-js/blob/saga/documents/battery.md` because it is easier to understand and follow.